### PR TITLE
Add support for local SPM package licenses

### DIFF
--- a/Sources/SourcePackagesParser/SourcePackagesParser.swift
+++ b/Sources/SourcePackagesParser/SourcePackagesParser.swift
@@ -29,13 +29,10 @@ final class SourcePackagesParser {
                 directoryURL = checkoutsURL.appending(path: repositoryName)
             } else if let url = URL(string: location), url.isFileURL {
                 directoryURL = url
+            } else if location.hasPrefix("/") {
+                directoryURL = URL(fileURLWithPath: location)
             } else {
-                let pathURL = URL(filePath: location)
-                if pathURL.path.hasPrefix("/") {
-                    directoryURL = pathURL
-                } else {
-                    directoryURL = sourcePackagesURL.appending(path: location)
-                }
+                directoryURL = sourcePackagesURL.appending(path: location)
             }
             guard let licenseBody = extractLicenseBody(directoryURL) else {
                 return nil

--- a/Tests/SourcePackagesParserTests/Resources/Local/LocalPackage/LICENSE
+++ b/Tests/SourcePackagesParserTests/Resources/Local/LocalPackage/LICENSE
@@ -1,0 +1,1 @@
+Local Package License

--- a/Tests/SourcePackagesParserTests/Resources/Local/workspace-state.json
+++ b/Tests/SourcePackagesParserTests/Resources/Local/workspace-state.json
@@ -1,0 +1,15 @@
+{
+  "object" : {
+    "dependencies" : [
+        {
+            "packageRef" : {
+                "identity" : "localpackage",
+                "kind" : "fileSystem",
+                "location" : "LocalPackage",
+                "name" : "LocalPackage"
+            }
+        }
+    ]
+  },
+  "version" : 7
+}

--- a/Tests/SourcePackagesParserTests/SourcePackagesParserTests.swift
+++ b/Tests/SourcePackagesParserTests/SourcePackagesParserTests.swift
@@ -135,5 +135,28 @@ struct SourcePackagesParserTests {
             #expect(urls[index].hasSuffix("\"https://github.com/dummy/Package-\(key).git\""))
         }
     }
+
+    @Test("Parse local package location")
+    func parse_local_package() throws {
+        let sourcePackagesURL = try #require(directoryURL("Local"))
+        let licenseListURL = sourcePackagesURL.appending(path: "LicenseList.swift")
+
+        let sppBinary = productsDirectory.appending(path: "spp")
+        let process = Process()
+        process.executableURL = sppBinary
+        process.arguments = [
+            licenseListURL.path(),
+            sourcePackagesURL.path()
+        ]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+
+        #expect(process.terminationStatus == 0)
+
+        let text = try String(contentsOf: licenseListURL)
+        #expect(text.contains("LocalPackage License"))
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- allow parsing license from local packages
- add new unit test with local package resource

## Testing
- `swift test --enable-code-coverage` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6881b45c43cc8325b52e0853eafb0d06