### PR TITLE
Update local license URLs

### DIFF
--- a/Sources/SourcePackagesParser/ExtraLicense.swift
+++ b/Sources/SourcePackagesParser/ExtraLicense.swift
@@ -7,5 +7,6 @@
 
 struct ExtraLicense: Decodable {
     let name: String
+    let url: String
     let licenseBody: String
 }

--- a/Sources/SourcePackagesParser/SourcePackagesParser.swift
+++ b/Sources/SourcePackagesParser/SourcePackagesParser.swift
@@ -37,7 +37,7 @@ final class SourcePackagesParser {
         if let data = try? Data(contentsOf: extraURL),
            let extras = try? JSONDecoder().decode([ExtraLicense].self, from: data) {
             libraries += extras.map {
-                Library(name: $0.name,url: "(local)",licenseBody: $0.licenseBody)
+                Library(name: $0.name, url: $0.url, licenseBody: $0.licenseBody)
             }
         }
         // Export LicenseList.swift

--- a/Sources/SourcePackagesParser/SourcePackagesParser.swift
+++ b/Sources/SourcePackagesParser/SourcePackagesParser.swift
@@ -34,10 +34,8 @@ final class SourcePackagesParser {
             )
         }
         let extraURL = sourcePackagesURL.appending(path: "local-licenses.json")
-        print("extraURL",extraURL)
         if let data = try? Data(contentsOf: extraURL),
            let extras = try? JSONDecoder().decode([ExtraLicense].self, from: data) {
-            print("extras",extras)
             libraries += extras.map {
                 Library(name: $0.name, url: $0.url, licenseBody: $0.licenseBody)
             }

--- a/Sources/SourcePackagesParser/SourcePackagesParser.swift
+++ b/Sources/SourcePackagesParser/SourcePackagesParser.swift
@@ -34,8 +34,10 @@ final class SourcePackagesParser {
             )
         }
         let extraURL = sourcePackagesURL.appending(path: "local-licenses.json")
+        print("extraURL",extraURL)
         if let data = try? Data(contentsOf: extraURL),
            let extras = try? JSONDecoder().decode([ExtraLicense].self, from: data) {
+            print("extras",extras)
             libraries += extras.map {
                 Library(name: $0.name, url: $0.url, licenseBody: $0.licenseBody)
             }

--- a/Tools/LLGenerateLocalLicenses/main.swift
+++ b/Tools/LLGenerateLocalLicenses/main.swift
@@ -19,8 +19,7 @@ let args = CommandLine.arguments
 guard let rootIdx = args.firstIndex(of: Arg.root),
       let outIdx  = args.firstIndex(of: Arg.out),
       args.indices.contains(rootIdx+1), args.indices.contains(outIdx+1) else {
-    let usage = "Usage: LLGenerateLocalLicenses --workspace <dir> --output <file>\n"
-    FileHandle.standardError.write(Data(usage.utf8))
+    fputs("Usage: LLGenerateLocalLicenses --workspace <dir> --output <file>\n", stderr)
     exit(1)
 }
 let workspace = URL(fileURLWithPath: args[rootIdx+1])

--- a/Tools/LLGenerateLocalLicenses/main.swift
+++ b/Tools/LLGenerateLocalLicenses/main.swift
@@ -53,6 +53,8 @@ for case let url as URL in enumerator where url.lastPathComponent == "Package.sw
            let match = config[range].split(separator: "=").last {
             print("match",match)
             urlString = match.trimmingCharacters(in: .whitespaces)
+                .components(separatedBy: "/").last!
+                .replacingOccurrences(of: ".git", with: "")
         }
         items.append(.init(name: pkgDir.lastPathComponent, url: urlString, licenseBody: text))
     }

--- a/Tools/LLGenerateLocalLicenses/main.swift
+++ b/Tools/LLGenerateLocalLicenses/main.swift
@@ -42,16 +42,13 @@ for case let url as URL in enumerator where url.lastPathComponent == "Package.sw
                                           includingPropertiesForKeys: nil)
         .first(where: { ["license","licence","copying","notice"]
             .contains($0.deletingPathExtension().lastPathComponent.lowercased()) })
-    print("Local package licenses 1")
     if let licURL = cand,
        let text = try? String(contentsOf: licURL, encoding: .utf8) {
         let gitConfig = pkgDir.appending(path: ".git/config")
-        print("gitConfig",gitConfig)
         var urlString = pkgDir.path
         if let config = try? String(contentsOf: gitConfig, encoding: .utf8),
            let range = config.range(of: #"url\s*=\s*([^\n]+)"#, options: .regularExpression),
            let match = config[range].split(separator: "=").last {
-            print("match",match)
             urlString = match.trimmingCharacters(in: .whitespaces)
         }
         items.append(.init(name: pkgDir.lastPathComponent, url: urlString, licenseBody: text))

--- a/Tools/LLGenerateLocalLicenses/main.swift
+++ b/Tools/LLGenerateLocalLicenses/main.swift
@@ -53,8 +53,6 @@ for case let url as URL in enumerator where url.lastPathComponent == "Package.sw
            let match = config[range].split(separator: "=").last {
             print("match",match)
             urlString = match.trimmingCharacters(in: .whitespaces)
-                .components(separatedBy: "/").last!
-                .replacingOccurrences(of: ".git", with: "")
         }
         items.append(.init(name: pkgDir.lastPathComponent, url: urlString, licenseBody: text))
     }

--- a/Tools/LLGenerateLocalLicenses/main.swift
+++ b/Tools/LLGenerateLocalLicenses/main.swift
@@ -43,7 +43,7 @@ for case let url as URL in enumerator where url.lastPathComponent == "Package.sw
                                           includingPropertiesForKeys: nil)
         .first(where: { ["license","licence","copying","notice"]
             .contains($0.deletingPathExtension().lastPathComponent.lowercased()) })
-
+    print("Local package licenses 1")
     if let licURL = cand,
        let text = try? String(contentsOf: licURL, encoding: .utf8) {
         let gitConfig = pkgDir.appending(path: ".git/config")

--- a/Tools/LLGenerateLocalLicenses/main.swift
+++ b/Tools/LLGenerateLocalLicenses/main.swift
@@ -47,10 +47,12 @@ for case let url as URL in enumerator where url.lastPathComponent == "Package.sw
     if let licURL = cand,
        let text = try? String(contentsOf: licURL, encoding: .utf8) {
         let gitConfig = pkgDir.appending(path: ".git/config")
+        print("gitConfig",gitConfig)
         var urlString = pkgDir.path
         if let config = try? String(contentsOf: gitConfig, encoding: .utf8),
            let range = config.range(of: #"url\s*=\s*([^\n]+)"#, options: .regularExpression),
            let match = config[range].split(separator: "=").last {
+            print("match",match)
             urlString = match.trimmingCharacters(in: .whitespaces)
         }
         items.append(.init(name: pkgDir.lastPathComponent, url: urlString, licenseBody: text))


### PR DESCRIPTION
## Summary
- add `url` field to `ExtraLicense`
- use the new field in `SourcePackagesParser`
- collect remote URLs when generating `local-licenses.json`

## Testing
- `swift build -c debug --product spp`
- `swift test -c debug` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6881e8f6c99c8325a6492cdc7d2c8e37